### PR TITLE
[bugfix] Token View Range fix

### DIFF
--- a/KSTokenView/KSTokenView.swift
+++ b/KSTokenView/KSTokenView.swift
@@ -901,31 +901,41 @@ extension KSTokenView : UITextFieldDelegate {
       }
     
       var searchString: String
-      let olderText = _tokenField.text
-      var olderTextTrimmed = olderText!
+      let olderText = _tokenField.text ?? ""
+      var olderTextTrimmed = olderText
     
       // remove the empty text marker from the beginning of the string
-      if (olderText?.first == KSTextEmpty.first) {
-        olderTextTrimmed = String(olderText![olderText!.index(olderText!.startIndex, offsetBy: 1)..<olderText!.endIndex])
+      if (olderText.first == KSTextEmpty.first) {
+				olderTextTrimmed = String(olderText.dropFirst())
       }
     
       // Check if character is removed at some index
       // Remove character at that index
       if (string.isEmpty) {
-        let first = String(olderText![..<olderText!.index(olderText!.startIndex, offsetBy: range.location)])
-        let second = String(olderText![olderText!.index(olderText!.startIndex, offsetBy: range.location+1)..<olderText!.endIndex])
-         searchString = first + second
-         searchString = searchString.trimmingCharacters(in: CharacterSet.whitespaces)
-         
+				// Safely convert NSRange to Swift Range
+				if let rangeInText = Range(range, in: olderText) {
+						var mutableText = olderText
+						mutableText.removeSubrange(rangeInText)
+						searchString = mutableText.trimmingCharacters(in: .whitespaces)
+				} else {
+						// Fallback for invalid range
+						searchString = olderText.trimmingCharacters(in: .whitespaces)
+				}
       } else { // new character added
          if (tokenizingCharacters.contains(string) && olderText != KSTextEmpty && olderTextTrimmed != "") {
             addTokenWithTitle(olderTextTrimmed, tokenObject: nil)
             _hideSearchResults()
             return false
          }
-         searchString = (olderText! as NSString).replacingCharacters(in: range, with: string)
+				 // Safely replace characters using NSString to handle NSRange properly
+				 if let olderTextNSString = olderText as NSString? {
+				   searchString = olderTextNSString.replacingCharacters(in: range, with: string)
+				 } else {
+					 searchString = string
+				 }
+				 // Remove the empty text marker if present
          if (searchString.first == KSTextEmpty.first) {
-            searchString = String(searchString[1...])
+					 searchString = String(searchString.dropFirst())
          }
       }
     

--- a/KSTokenView/KSTokenView.swift
+++ b/KSTokenView/KSTokenView.swift
@@ -925,19 +925,19 @@ extension KSTokenView : UITextFieldDelegate {
         if (tokenizingCharacters.contains(string) && olderText != KSTextEmpty && olderTextTrimmed != "") {
           addTokenWithTitle(olderTextTrimmed, tokenObject: nil)
           _hideSearchResults()
-					return false
-				}
-				// Safely replace characters using NSString to handle NSRange properly
-				if let olderTextNSString = olderText as NSString? {
-					searchString = olderTextNSString.replacingCharacters(in: range, with: string)
-				} else {
-					searchString = string
-				}
-				// Remove the empty text marker if present
-				if (searchString.first == KSTextEmpty.first) {
-					searchString = String(searchString.dropFirst())
-				}
-		}
+          return false
+        }
+        // Safely replace characters using NSString to handle NSRange properly
+        if let olderTextNSString = olderText as NSString? {
+          searchString = olderTextNSString.replacingCharacters(in: range, with: string)
+        } else {
+          searchString = string
+        }
+        // Remove the empty text marker if present
+        if (searchString.first == KSTextEmpty.first) {
+          searchString = String(searchString.dropFirst())
+        }
+      }
     
       // Allow all other characters
       if (searchString.count >= minimumCharactersToSearch && searchString != "\n") {

--- a/KSTokenView/KSTokenView.swift
+++ b/KSTokenView/KSTokenView.swift
@@ -906,38 +906,38 @@ extension KSTokenView : UITextFieldDelegate {
     
       // remove the empty text marker from the beginning of the string
       if (olderText.first == KSTextEmpty.first) {
-				olderTextTrimmed = String(olderText.dropFirst())
+        olderTextTrimmed = String(olderText.dropFirst())
       }
     
       // Check if character is removed at some index
       // Remove character at that index
       if (string.isEmpty) {
-				// Safely convert NSRange to Swift Range
-				if let rangeInText = Range(range, in: olderText) {
-						var mutableText = olderText
-						mutableText.removeSubrange(rangeInText)
-						searchString = mutableText.trimmingCharacters(in: .whitespaces)
-				} else {
-						// Fallback for invalid range
-						searchString = olderText.trimmingCharacters(in: .whitespaces)
-				}
+        // Safely convert NSRange to Swift Range
+        if let rangeInText = Range(range, in: olderText) {
+          var mutableText = olderText
+          mutableText.removeSubrange(rangeInText)
+          searchString = mutableText.trimmingCharacters(in: .whitespaces)
+        } else {
+          // Fallback for invalid range
+          searchString = olderText.trimmingCharacters(in: .whitespaces)
+        }
       } else { // new character added
-         if (tokenizingCharacters.contains(string) && olderText != KSTextEmpty && olderTextTrimmed != "") {
-            addTokenWithTitle(olderTextTrimmed, tokenObject: nil)
-            _hideSearchResults()
-            return false
-         }
-				 // Safely replace characters using NSString to handle NSRange properly
-				 if let olderTextNSString = olderText as NSString? {
-				   searchString = olderTextNSString.replacingCharacters(in: range, with: string)
-				 } else {
-					 searchString = string
-				 }
-				 // Remove the empty text marker if present
-         if (searchString.first == KSTextEmpty.first) {
-					 searchString = String(searchString.dropFirst())
-         }
-      }
+        if (tokenizingCharacters.contains(string) && olderText != KSTextEmpty && olderTextTrimmed != "") {
+          addTokenWithTitle(olderTextTrimmed, tokenObject: nil)
+          _hideSearchResults()
+					return false
+				}
+				// Safely replace characters using NSString to handle NSRange properly
+				if let olderTextNSString = olderText as NSString? {
+					searchString = olderTextNSString.replacingCharacters(in: range, with: string)
+				} else {
+					searchString = string
+				}
+				// Remove the empty text marker if present
+				if (searchString.first == KSTextEmpty.first) {
+					searchString = String(searchString.dropFirst())
+				}
+		}
     
       // Allow all other characters
       if (searchString.count >= minimumCharactersToSearch && searchString != "\n") {


### PR DESCRIPTION
Earlier, we were assuming range.location directly corresponds to a valid index in the String.
This assumption breaks for multi-byte characters (non ASCII such as different language characters).